### PR TITLE
use dl.k8s.io instead of hardcoded GCS URIs

### DIFF
--- a/build/debian-hyperkube-base/Makefile
+++ b/build/debian-hyperkube-base/Makefile
@@ -35,7 +35,7 @@ all: push
 
 cni-tars/$(CNI_TARBALL):
 	mkdir -p cni-tars/
-	cd cni-tars/ && curl -sSLO --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/${CNI_TARBALL}
+	cd cni-tars/ && curl -sSLO --retry 5 https://dl.k8s.io/network-plugins/${CNI_TARBALL}
 
 clean:
 	rm -rf cni-tars/

--- a/hack/get-build.sh
+++ b/hack/get-build.sh
@@ -22,8 +22,7 @@ KUBE_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 source "${KUBE_ROOT}/cluster/common.sh"
 
-declare -r KUBE_RELEASE_BUCKET_URL="https://storage.googleapis.com/kubernetes-release"
-declare -r KUBE_DEV_RELEASE_BUCKET_URL="https://storage.googleapis.com/kubernetes-release-dev"
+declare -r KUBE_DOWNLOAD_URL="https://dl.k8s.io"
 declare -r KUBE_TAR_NAME="kubernetes.tar.gz"
 
 usage() {
@@ -73,9 +72,9 @@ if [[ "${print_version}" == "true" ]]; then
 else
   echo "Using version at ${1}: ${KUBE_VERSION}" >&2
   if [[ ${KUBE_VERSION} =~ ${KUBE_RELEASE_VERSION_REGEX} ]]; then
-    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_RELEASE_BUCKET_URL}/release/${KUBE_VERSION}/${KUBE_TAR_NAME}"
+    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_DOWNLOAD_URL}/release/${KUBE_VERSION}/${KUBE_TAR_NAME}"
   elif [[ ${KUBE_VERSION} =~ ${KUBE_CI_VERSION_REGEX} ]]; then
-    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_DEV_RELEASE_BUCKET_URL}/ci/${KUBE_VERSION}/${KUBE_TAR_NAME}"
+    curl --fail -o "kubernetes-${KUBE_VERSION}.tar.gz" "${KUBE_DOWNLOAD_URL}/ci/${KUBE_VERSION}/${KUBE_TAR_NAME}"
   else
     echo "Version doesn't match regexp" >&2
     exit 1


### PR DESCRIPTION
The only time a kubernetes GCS bucket name should be showing up in a
hardcoded URI is if `gsutil` is being used (e.g. gsutil cp gs://foo/bar .)

Otherwise, for tools like `curl` or `wget`, dl.k8s.io is much nicer for us
as a project, since we can transparently change where that redirects to
without having to change code everywhere

These changes will mean no changes will be necessary to accommodate a
`gs://kubernetes-release` -> `gs://k8s-release` migration equivalent of
the CI migration we're going through right now

These changes also address the `gs://kubernetes-release-dev` references
currently used by this repo (ref:
https://github.com/kubernetes/k8s.io/issues/2318)